### PR TITLE
No need to load 'os'

### DIFF
--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import h5py, os"
+    "import h5py"
    ]
   },
   {

--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -34,8 +34,7 @@
    ],
    "source": [
     "# Create some example HDF5 data to show\n",
-    "os.unlink(\"example.h5\")\n",
-    "f = h5py.File(\"example.h5\")\n",
+    "f = h5py.File(\"example.h5\", \"w\")\n",
     "f.create_dataset(\"/group1/subgroup1/dataset1\", (200,), dtype='u8')\n",
     "f.create_dataset(\"/group1/subgroup1/dataset2\", (2, 128, 500), dtype='f4')\n",
     "f.create_dataset(\"/group1/subgroup2/dataset1\", (12,), dtype='i2')\n",


### PR DESCRIPTION
Small change as `w` already truncate or create a file, it start from nothing without need to import `os`.