### PR TITLE
Support h5pyd

### DIFF
--- a/h5glance/generate.py
+++ b/h5glance/generate.py
@@ -71,9 +71,13 @@ def checkbox_w_label(label_content):
     return [c, l]
 
 def item_for_dataset(name, ds):
-    shape = " × ".join(str(n) for n in ds.shape)
     namespan = Span(name)
     namespan.add_css_classes("h5glance-dataset-name")
+    if ds is None:
+        # h5pyd can return None dataset for external links
+        li = ListItem(namespan)
+        return li
+    shape = " × ".join(str(n) for n in ds.shape)
     copylink = Link("#", "[📋]")
     copylink.set_attribute("data-hdf5-path", ds.name)
     copylink.add_css_classes("h5glance-dataset-copylink")

--- a/h5glance/generate.py
+++ b/h5glance/generate.py
@@ -4,6 +4,8 @@ from htmlgen import (Document, Element, Division, UnorderedList, Checkbox,
                      )
 from pathlib import Path
 
+from . import utils
+
 _PKGDIR = Path(__file__).parent
 
 class Style(Element):
@@ -85,7 +87,7 @@ def item_for_dataset(name, ds):
 def item_for_group(gname, grp):
     subgroups, datasets = [], []
     for name, obj in sorted(grp.items()):
-        if isinstance(obj, h5py.Group):
+        if utils.is_group(obj):
             subgroups.append((name, obj))
         else:
             datasets.append((name, obj))
@@ -96,16 +98,16 @@ def item_for_group(gname, grp):
     ))
 
 def file_or_grp_name(obj):
-    if isinstance(obj, h5py.File):
+    if utils.is_file(obj):
         return obj.filename
-    elif isinstance(obj, h5py.Group):
+    elif utils.is_group(obj):
         return obj.name
     return obj
 
 treeview_ids = id_generator("h5glance-container-%d")
 
 def make_fragment(obj):
-    if isinstance(obj, h5py.Group):
+    if utils.is_group(obj):
         name = file_or_grp_name(obj)
         ct = make_list(item_for_group(name, obj))
     elif isinstance(obj, (str, Path)) and h5py.is_hdf5(obj):

--- a/h5glance/utils.py
+++ b/h5glance/utils.py
@@ -2,10 +2,11 @@
 """
 import h5py
 
-_mapping = {}
-_mapping[h5py.File] = "file"
-_mapping[h5py.Group] = "group"
-_mapping[h5py.Dataset] = "dataset"
+_mapping = {
+    h5py.File: "file",
+    h5py.Group: "group",
+    h5py.Dataset: "dataset",
+}
 
 
 def register_h5pyd():

--- a/h5glance/utils.py
+++ b/h5glance/utils.py
@@ -2,17 +2,34 @@
 """
 import h5py
 
+try:
+    import h5pyd
+except ImportError:
+    h5pyd = None
+
 
 def is_file(obj):
     """Returns true if the object is a h5py-like file."""
-    return isinstance(obj, h5py.File)
+    if isinstance(obj, h5py.File):
+        return True
+    if h5pyd is not None and isinstance(obj, h5pyd.File):
+        return True
+    return False
 
 
 def is_dataset(obj):
     """Returns true if the object is a h5py-like dataset."""
-    return isinstance(obj, h5py.Dataset)
+    if isinstance(obj, h5py.Dataset):
+        return True
+    if h5pyd is not None and isinstance(obj, h5pyd.Dataset):
+        return True
+    return False
 
 
 def is_group(obj):
     """Returns true if the object is a h5py-like group."""
-    return isinstance(obj, h5py.Group)
+    if isinstance(obj, h5py.Group):
+        return True
+    if h5pyd is not None and isinstance(obj, h5pyd.Group):
+        return True
+    return False

--- a/h5glance/utils.py
+++ b/h5glance/utils.py
@@ -2,34 +2,47 @@
 """
 import h5py
 
-try:
+_mapping = {}
+_mapping[h5py.File] = "file"
+_mapping[h5py.Group] = "group"
+_mapping[h5py.Dataset] = "dataset"
+
+
+def register_h5pyd():
     import h5pyd
-except ImportError:
-    h5pyd = None
+    _mapping[h5pyd.File] = "file"
+    _mapping[h5pyd.Group] = "group"
+    _mapping[h5pyd.Dataset] = "dataset"
+
+
+def check_class(obj_class):
+    """Check registered class"""
+    lib = obj_class.__module__.split(".")[0]
+    if lib == "h5pyd":
+        register_h5pyd()
+    else:
+        _mapping[obj_class] = None
 
 
 def is_file(obj):
     """Returns true if the object is a h5py-like file."""
-    if isinstance(obj, h5py.File):
-        return True
-    if h5pyd is not None and isinstance(obj, h5pyd.File):
-        return True
-    return False
+    obj_class = obj.__class__
+    if obj_class not in _mapping:
+        check_class(obj_class)
+    return _mapping.get(obj_class, None) == "file"
 
 
 def is_dataset(obj):
     """Returns true if the object is a h5py-like dataset."""
-    if isinstance(obj, h5py.Dataset):
-        return True
-    if h5pyd is not None and isinstance(obj, h5pyd.Dataset):
-        return True
-    return False
+    obj_class = obj.__class__
+    if obj_class not in _mapping:
+        check_class(obj_class)
+    return _mapping.get(obj_class, None) == "dataset"
 
 
 def is_group(obj):
     """Returns true if the object is a h5py-like group."""
-    if isinstance(obj, h5py.Group):
-        return True
-    if h5pyd is not None and isinstance(obj, h5pyd.Group):
-        return True
-    return False
+    obj_class = obj.__class__
+    if obj_class not in _mapping:
+        check_class(obj_class)
+    return _mapping.get(obj_class, None) in ["file", "group"]

--- a/h5glance/utils.py
+++ b/h5glance/utils.py
@@ -24,25 +24,31 @@ def check_class(obj_class):
         _mapping[obj_class] = None
 
 
-def is_file(obj):
-    """Returns true if the object is a h5py-like file."""
-    obj_class = obj.__class__
+def get_h5py_kind(obj):
+    """Returns the h5py-like kind of an object.
+
+    The result can be `file`, `group`, `dataset` or `None` if the object is not
+    an h5py-like object.
+    """
+    obj_class = type(obj)
     if obj_class not in _mapping:
         check_class(obj_class)
-    return _mapping.get(obj_class, None) == "file"
+    return _mapping.get(obj_class, None)
+
+
+def is_file(obj):
+    """Returns true if the object is a h5py-like file."""
+    kind = get_h5py_kind(obj)
+    return kind == "file"
 
 
 def is_dataset(obj):
     """Returns true if the object is a h5py-like dataset."""
-    obj_class = obj.__class__
-    if obj_class not in _mapping:
-        check_class(obj_class)
-    return _mapping.get(obj_class, None) == "dataset"
+    kind = get_h5py_kind(obj)
+    return kind == "dataset"
 
 
 def is_group(obj):
     """Returns true if the object is a h5py-like group."""
-    obj_class = obj.__class__
-    if obj_class not in _mapping:
-        check_class(obj_class)
-    return _mapping.get(obj_class, None) in ["file", "group"]
+    kind = get_h5py_kind(obj)
+    return kind in ["file", "group"]

--- a/h5glance/utils.py
+++ b/h5glance/utils.py
@@ -1,0 +1,18 @@
+"""Helper functions
+"""
+import h5py
+
+
+def is_file(obj):
+    """Returns true if the object is a h5py-like file."""
+    return isinstance(obj, h5py.File)
+
+
+def is_dataset(obj):
+    """Returns true if the object is a h5py-like dataset."""
+    return isinstance(obj, h5py.Dataset)
+
+
+def is_group(obj):
+    """Returns true if the object is a h5py-like group."""
+    return isinstance(obj, h5py.Group)


### PR DESCRIPTION
Support `h5pyd` only on the notebook part.

- Create abstraction to check object types
- Use `__module__` from provided object to check if the library is known. If the library is `h5pyd`, register it's class objects.

I use `h5serv` with it's default configuration and file
```
git clone https://github.com/HDFGroup/h5serv.git
cd h5serv
python h5serv
```

Install `h5pyd`
```
pip install h5pyd
```

I checked using a notebook

![Screenshot from 2019-04-16 15-09-38](https://user-images.githubusercontent.com/7579321/56212788-02fdf900-605b-11e9-89a3-9aa207a0cc58.png)

