### PR TITLE
Improve expand/collapse chars

### DIFF
--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -128,14 +128,14 @@
        "\n",
        ".h5glance-css-treeview label::before\n",
        "{\n",
-       "\tcontent: \"+\";\n",
+       "\tcontent: \"\\229e\"; /* squared plus */\n",
        "\twidth: 1.5em;\n",
        "\tvertical-align: middle;\n",
        "}\n",
        "\n",
        ".h5glance-css-treeview input:checked + label::before\n",
        "{\n",
-       "    content: \"–\";\n",
+       "    content: \"\\229f\";  /* squared minus */\n",
        "}\n",
        "\n",
        "/* webkit adjacent element selector bugfix */\n",
@@ -232,7 +232,7 @@
        "    }\n",
        "\n",
        "    function enable_copylinks(parent) {\n",
-       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\")\n",
+       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\");\n",
        "        links.forEach(function (link) {\n",
        "            link.addEventListener(\"click\", copy_event_handler);\n",
        "        });\n",
@@ -246,7 +246,7 @@
        "</script></div>"
       ],
       "text/plain": [
-       "<h5glance.generate.H5Glance at 0x7f7ea866dda0>"
+       "<h5glance.generate.H5Glance at 0x7fcf704dcf98>"
       ]
      },
      "execution_count": 3,
@@ -337,14 +337,14 @@
        "\n",
        ".h5glance-css-treeview label::before\n",
        "{\n",
-       "\tcontent: \"+\";\n",
+       "\tcontent: \"\\229e\"; /* squared plus */\n",
        "\twidth: 1.5em;\n",
        "\tvertical-align: middle;\n",
        "}\n",
        "\n",
        ".h5glance-css-treeview input:checked + label::before\n",
        "{\n",
-       "    content: \"–\";\n",
+       "    content: \"\\229f\";  /* squared minus */\n",
        "}\n",
        "\n",
        "/* webkit adjacent element selector bugfix */\n",
@@ -441,7 +441,7 @@
        "    }\n",
        "\n",
        "    function enable_copylinks(parent) {\n",
-       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\")\n",
+       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\");\n",
        "        links.forEach(function (link) {\n",
        "            link.addEventListener(\"click\", copy_event_handler);\n",
        "        });\n",
@@ -455,7 +455,7 @@
        "</script></div>"
       ],
       "text/plain": [
-       "<h5glance.generate.H5Glance at 0x7f7e7fb7c550>"
+       "<h5glance.generate.H5Glance at 0x7fcf6b995860>"
       ]
      },
      "execution_count": 4,
@@ -564,14 +564,14 @@
        "\n",
        ".h5glance-css-treeview label::before\n",
        "{\n",
-       "\tcontent: \"+\";\n",
+       "\tcontent: \"\\229e\"; /* squared plus */\n",
        "\twidth: 1.5em;\n",
        "\tvertical-align: middle;\n",
        "}\n",
        "\n",
        ".h5glance-css-treeview input:checked + label::before\n",
        "{\n",
-       "    content: \"–\";\n",
+       "    content: \"\\229f\";  /* squared minus */\n",
        "}\n",
        "\n",
        "/* webkit adjacent element selector bugfix */\n",
@@ -668,7 +668,7 @@
        "    }\n",
        "\n",
        "    function enable_copylinks(parent) {\n",
-       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\")\n",
+       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\");\n",
        "        links.forEach(function (link) {\n",
        "            link.addEventListener(\"click\", copy_event_handler);\n",
        "        });\n",
@@ -772,14 +772,14 @@
        "\n",
        ".h5glance-css-treeview label::before\n",
        "{\n",
-       "\tcontent: \"+\";\n",
+       "\tcontent: \"\\229e\"; /* squared plus */\n",
        "\twidth: 1.5em;\n",
        "\tvertical-align: middle;\n",
        "}\n",
        "\n",
        ".h5glance-css-treeview input:checked + label::before\n",
        "{\n",
-       "    content: \"–\";\n",
+       "    content: \"\\229f\";  /* squared minus */\n",
        "}\n",
        "\n",
        "/* webkit adjacent element selector bugfix */\n",
@@ -876,7 +876,7 @@
        "    }\n",
        "\n",
        "    function enable_copylinks(parent) {\n",
-       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\")\n",
+       "        let links = parent.querySelectorAll(\".h5glance-dataset-copylink\");\n",
        "        links.forEach(function (link) {\n",
        "            link.addEventListener(\"click\", copy_event_handler);\n",
        "        });\n",
@@ -901,6 +901,13 @@
    "source": [
     "f['group1']"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/h5glance/treeview.css
+++ b/h5glance/treeview.css
@@ -75,7 +75,7 @@
 
 .h5glance-css-treeview input:checked + label::before
 {
-    content: "–";
+    content: "\2212";  /* Minus character using same width as + */
 }
 
 /* webkit adjacent element selector bugfix */

--- a/h5glance/treeview.css
+++ b/h5glance/treeview.css
@@ -68,14 +68,14 @@
 
 .h5glance-css-treeview label::before
 {
-	content: "+";
+	content: "\229e"; /* squared plus */
 	width: 1.5em;
 	vertical-align: middle;
 }
 
 .h5glance-css-treeview input:checked + label::before
 {
-    content: "\2212";  /* Minus character using same width as + */
+    content: "\229f";  /* squared minus */
 }
 
 /* webkit adjacent element selector bugfix */


### PR DESCRIPTION
Here i created 2 commits to improve the rendering of the small +/- characters.

- The first commit using a mathematical minus character (it have the same which with +), then there is no blinking when it is updated
- And my second commit uses squared +/-

That's a low cost, small improvement, if you trust people now uses decent unicode fonts.

Here is a preview.
![Screenshot from 2019-04-16 16-39-13](https://user-images.githubusercontent.com/7579321/56219084-70635700-6066-11e9-9636-1820343b673e.png)
