### PR TITLE
Show data for small array attributes

### DIFF
--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -44,7 +44,10 @@ def fmt_attr(key, attrs):
         return "<Unable to read attribute>"
 
     if isinstance(v, numpy.ndarray):
-        sv = 'array [{}: {}]'.format(fmt_dtype(v.dtype), fmt_shape(v.shape))
+        if v.ndim < 2:
+            sv = numpy.array2string(v, precision=5, threshold=10)
+        else:
+            sv = 'array [{}: {}]'.format(fmt_dtype(v.dtype), fmt_shape(v.shape))
     else:
         sv = repr(v)
         if len(sv) > 50:


### PR DESCRIPTION
NeXus files use attributes extensively, and currently arrays in the attributes only appear like `array [float32: 3]`.

This makes the contents of 1D arrays up to 10 items visible inline, like this:

```
  │ │ ├ARRAY_D0Q0M0A0
  │ │ │ ├1 attributes:
  │ │ │ │ └NX_class: b'NXdetector_module'
  │ │ │ ├data_origin      [int32: 2]
  │ │ │ ├data_size        [int32: 2]
  │ │ │ ├fast_pixel_direction     [float32: 1]
  │ │ │ │ └5 attributes:
  │ │ │ │   ├depends_on: '/entry/instrument/J...tions/AXIS_D0Q0M0A0'
  │ │ │ │   ├offset: [0. 0. 0.]
  │ │ │ │   ├transformation_type: b'translation'
  │ │ │ │   ├units: b'mm'
  │ │ │ │   └vector: [-1.      -0.00178  0.     ]
```