### PR TITLE
Add -s/--slice option to choose visible slice of dataset

### DIFF
--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -309,8 +309,8 @@ def main(argv=None):
         help="Show attributes of groups",
     )
     ap.add_argument('-s', '--slice',
-        help="Select part of a dataset to examine with a Python slice "
-             "expression, e.g. 0,100:110",
+        help="Select part of a dataset to examine, using Python slicing and "
+             "indexing as for a numpy array, e.g. 0,100:110",
     )
     ap.add_argument('--version', action='version',
                     version='H5glance {}'.format(__version__))

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -54,7 +54,7 @@ def fmt_attr(key, attrs):
             sv = sv[:20] + '...' + sv[-20:]
     return sv
 
-def print_dataset_info(ds: h5py.Dataset, file=None):
+def print_dataset_info(ds: h5py.Dataset, slice_expr=None, file=None):
     """Print detailed information for an HDF5 dataset."""
     print('      dtype:', fmt_dtype(ds.dtype), file=file)
     print('      shape:', fmt_shape(ds.shape), file=file)
@@ -70,7 +70,15 @@ def print_dataset_info(ds: h5py.Dataset, file=None):
     if sys.stdout.isatty():
         numpy.set_printoptions(linewidth=get_terminal_size()[0])
 
-    if ds.size and ds.size > 0:  # size is None for empty datasets
+    if slice_expr:
+        print("\nselected data [{}]:".format(slice_expr), file=file)
+        try:
+            arr = eval('ds[{}]'.format(slice_expr), {'ds': ds})
+        except Exception as e:
+            print("Error slicing", e, file=file)
+        else:
+            print(arr, file=file)
+    elif ds.size and ds.size > 0:  # size is None for empty datasets
         print('\nsample data:', file=file)
         if ds.ndim == 0:
             print(ds[()], file=file)
@@ -207,7 +215,7 @@ def page(text):
     pager_cmd = shlex.split(os.environ.get('PAGER') or 'less -r')
     run(pager_cmd, input=text.encode('utf-8'))
 
-def display_h5_obj(file: h5py.File, path=None, expand_attrs=False):
+def display_h5_obj(file: h5py.File, path=None, expand_attrs=False, slice_expr=None):
     """Display information on an HDF5 file, group or dataset
 
     This is the central function for the h5glance command line tool.
@@ -221,11 +229,13 @@ def display_h5_obj(file: h5py.File, path=None, expand_attrs=False):
         obj = file
 
     if isinstance(obj, h5py.Group):
+        if slice_expr is not None:
+            sys.exit("Slicing is only allowed for datasets")
         tvb = TreeViewBuilder(expand_attrs=expand_attrs)
         print_tree(tvb.object_node(obj, root), file=sio)
     elif isinstance(obj, h5py.Dataset):
         print(root, file=sio)
-        print_dataset_info(obj, file=sio)
+        print_dataset_info(obj, slice_expr, file=sio)
     else:
         sys.exit("What is this? " + repr(obj))
 
@@ -297,6 +307,10 @@ def main(argv=None):
     )
     ap.add_argument('--attrs', action='store_true',
         help="Show attributes of groups",
+    )
+    ap.add_argument('-s', '--slice',
+        help="Select part of a dataset to examine with a Python slice "
+             "expression, e.g. 0,100:110",
     )
     ap.add_argument('--version', action='version',
                     version='H5glance {}'.format(__version__))

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -329,4 +329,4 @@ def main(argv=None):
         path = prompt_for_path(args.file)
 
     with h5py.File(args.file, 'r') as f:
-        display_h5_obj(f, path, expand_attrs=args.attrs)
+        display_h5_obj(f, path, slice_expr=args.slice, expand_attrs=args.attrs)

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -67,6 +67,7 @@ def print_dataset_info(ds: h5py.Dataset, slice_expr=None, file=None):
         print('compression: {} (options: {})'
               .format(ds.compression, ds.compression_opts), file=file)
 
+    numpy.set_printoptions(threshold=numpy.inf)
     if sys.stdout.isatty():
         numpy.set_printoptions(linewidth=get_terminal_size()[0])
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -39,6 +39,14 @@ def test_dataset_info(simple_h5_file):
     assert 'dtype: float32' in out
     assert 'shape: 2 × 128 × 500' in out
 
+def test_dataset_slice(simple_h5_file):
+    sio = io.StringIO()
+    terminal.print_dataset_info(simple_h5_file["/group1/subgroup1/dataset2"],
+                                slice_expr='0,0,5:9', file=sio)
+    out = sio.getvalue()
+    assert '[0,0,5:9]' in out
+    assert '[0. 0. 0. 0.]' in out
+
 def test_compound_types(simple_h5_file):
     sio = io.StringIO()
     terminal.print_dataset_info(simple_h5_file["compound"], file=sio)


### PR DESCRIPTION
Currently, `h5glance file.h5 path/to/dataset` shows a sample of the data - the first 10x10 values, for a dataset with at least 2 dimensions. This allows the user to override that and specify which data to look at:

```
h5glance xmpl-3.cxi entry_1/instrument_1/detector_1/data -s 0,0,10:12,:5
```

The syntax is a Python/numpy/h5py slice expression - I don't know any more general way to carve up a multidimensional space. There's no limit on the amount of data it will load, though numpy's default printing options will only show up to 1000 elements before it collapses the array with `...` ellipsis.

This is meant for getting a close-up view of a small amount of data, e.g. if `extra-data-validate` points out a problem in a specific part of the index. It's not a good way to see a lot of data - for that you're  better off using other tools that can plot or summarise the data.