### PR TITLE
Add 'Why H5Glance' section to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,3 +48,32 @@ The HTML interface lets you inspect HDF5 files in a Jupyter Notebook.
 `Demo.ipynb <https://nbviewer.jupyter.org/github/European-XFEL/h5glance/blob/master/Demo.ipynb>`_
 shows how to use it.
 
+Why H5Glance?
+-------------
+
+There are plenty of other tools to view HDF5 files, including
+`HDFView <https://www.hdfgroup.org/downloads/hdfview/>`_ and
+`ViTables <https://vitables.org/>`_, as well as various web-based viewers in
+development. Why might you choose H5Glance?
+
+- Practical terminal interface: if you're working in a terminal, it's much
+  quicker to use something there than to start a GUI application and click
+  through it.
+  - Tab completions are part of this - take a moment to set them up (see above).
+- Static Jupyter views: H5Glance shows your HDF5 objects in simple HTML, which
+  doesn't talk to the server. Export your notebook to HTML, or `view it on
+  nbviewer <https://nbviewer.jupyter.org/github/European-XFEL/h5glance/blob/master/Demo.ipynb>`_,
+  and the H5Glance view is still there.
+- Deeply nested structure: It was written at `European XFEL <https://www.xfel.eu/>`_,
+  where data files can easily have 6 layers of nested groups. It tries to make
+  working with that easy.
+
+Some things it's not designed for:
+
+- Viewing data: The terminal interface can show raw data, but it focuses on the
+  structure of HDF5 files, not their content. H5Glance won't show you plots or
+  images.
+- Machine-readable output: It's meant for people, not programs.
+  In Python, your code can use `h5py <https://docs.h5py.org/en/stable/>`_.
+  For shell pipelines, use tools like ``h5ls`` and ``h5dump``.
+

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,9 @@ development. Why might you choose H5Glance?
 - Practical terminal interface: if you're working in a terminal, it's much
   quicker to use something there than to start a GUI application and click
   through it.
+
   - Tab completions are part of this - take a moment to set them up (see above).
+
 - Static Jupyter views: H5Glance shows your HDF5 objects in simple HTML, which
   doesn't talk to the server. Export your notebook to HTML, or `view it on
   nbviewer <https://nbviewer.jupyter.org/github/European-XFEL/h5glance/blob/master/Demo.ipynb>`_,


### PR DESCRIPTION
There are [a lot of HDF5 viewers](https://github.com/panosc-eu/panosc/blob/master/Work%20Packages/WP4%20Data%20analysis%20services/resources/hdf5-viewers.rst), and I wanted to tell people why they might want H5Glance. cc @RobertRosca 

I've also listed a couple of non-goals. This is partly to give people a sense of when they might not want it, and partly a signal that these things are out of scope, in case of enthusiastic contributors. I've had some success on another project with explicitly describing what is out of scope.