### PR TITLE
Provide text view in IPython as well as HTML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
+  - "3.8"
+  - "3.7"
   - "3.6"
-  - "3.5"
 install:
-  - pip install flit
-  - flit install
+  - pip install .
 script: py.test

--- a/h5glance/__init__.py
+++ b/h5glance/__init__.py
@@ -1,4 +1,4 @@
 """Explore HDF5 files in an HTML view"""
-from .generate import H5Glance, install_ipython_h5py_display
+from .ipython import H5Glance, install_ipython_h5py_display
 
 __version__ = "0.7"

--- a/h5glance/html.py
+++ b/h5glance/html.py
@@ -160,19 +160,4 @@ def h5obj_to_html(obj):
     )
     return str(div)
 
-class H5Glance:
-    """View an HDF5 object in a Jupyter notebook"""
-    def __init__(self, obj):
-        self.obj = obj
 
-    def _repr_html_(self):
-        return h5obj_to_html(self.obj)
-
-def install_ipython_h5py_display():
-    """Call inside IPython to install HTML views for h5py groups and files"""
-    from IPython import get_ipython
-    ip = get_ipython()
-    if ip is None:
-        raise EnvironmentError("This function is to be called in IPython")
-    html_formatter = ip.display_formatter.formatters['text/html']
-    html_formatter.for_type(h5py.Group, h5obj_to_html)

--- a/h5glance/html_cli.py
+++ b/h5glance/html_cli.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import webbrowser
 
-from .generate import make_document
+from .html import make_document
 
 def main(argv=None):
     ap = argparse.ArgumentParser(prog="h5glance",

--- a/h5glance/ipython.py
+++ b/h5glance/ipython.py
@@ -12,7 +12,7 @@ class H5Glance:
         return h5obj_to_html(self.obj)
 
     def __repr__(self):
-        return group_to_str(self.obj)
+        return group_to_str(self.obj, max_depth=1)
 
 def install_ipython_h5py_display(html=True, text=True):
     """Call inside IPython to install HTML/text views for h5py groups and files"""

--- a/h5glance/ipython.py
+++ b/h5glance/ipython.py
@@ -1,6 +1,7 @@
 import h5py
 
 from .html import h5obj_to_html
+from .terminal import group_to_str
 
 class H5Glance:
     """View an HDF5 object in a Jupyter notebook"""
@@ -10,11 +11,19 @@ class H5Glance:
     def _repr_html_(self):
         return h5obj_to_html(self.obj)
 
-def install_ipython_h5py_display():
-    """Call inside IPython to install HTML views for h5py groups and files"""
+    def __repr__(self):
+        return group_to_str(self.obj)
+
+def install_ipython_h5py_display(html=True, text=True):
+    """Call inside IPython to install HTML/text views for h5py groups and files"""
     from IPython import get_ipython
     ip = get_ipython()
     if ip is None:
         raise EnvironmentError("This function is to be called in IPython")
-    html_formatter = ip.display_formatter.formatters['text/html']
-    html_formatter.for_type(h5py.Group, h5obj_to_html)
+
+    if html:
+        html_formatter = ip.display_formatter.formatters['text/html']
+        html_formatter.for_type(h5py.Group, h5obj_to_html)
+    if text:
+        text_formatter = ip.display_formatter.formatters['text/plain']
+        text_formatter.for_type(h5py.Group, group_to_str)

--- a/h5glance/ipython.py
+++ b/h5glance/ipython.py
@@ -27,6 +27,7 @@ def install_ipython_h5py_display(html=True, text=True):
     if text:
         text_formatter = ip.display_formatter.formatters['text/plain']
         text_formatter.for_type(h5py.Group, pretty_print_group)
+        text_formatter.for_type(h5py.File, pretty_print_group)
 
 def pretty_print_group(obj, p, cycle):
     p.text(group_to_str(obj))

--- a/h5glance/ipython.py
+++ b/h5glance/ipython.py
@@ -26,4 +26,7 @@ def install_ipython_h5py_display(html=True, text=True):
         html_formatter.for_type(h5py.Group, h5obj_to_html)
     if text:
         text_formatter = ip.display_formatter.formatters['text/plain']
-        text_formatter.for_type(h5py.Group, group_to_str)
+        text_formatter.for_type(h5py.Group, pretty_print_group)
+
+def pretty_print_group(obj, p, cycle):
+    p.text(group_to_str(obj))

--- a/h5glance/ipython.py
+++ b/h5glance/ipython.py
@@ -1,0 +1,20 @@
+import h5py
+
+from .html import h5obj_to_html
+
+class H5Glance:
+    """View an HDF5 object in a Jupyter notebook"""
+    def __init__(self, obj):
+        self.obj = obj
+
+    def _repr_html_(self):
+        return h5obj_to_html(self.obj)
+
+def install_ipython_h5py_display():
+    """Call inside IPython to install HTML views for h5py groups and files"""
+    from IPython import get_ipython
+    ip = get_ipython()
+    if ip is None:
+        raise EnvironmentError("This function is to be called in IPython")
+    html_formatter = ip.display_formatter.formatters['text/html']
+    html_formatter.for_type(h5py.Group, h5obj_to_html)

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -157,7 +157,7 @@ class TreeViewBuilder:
             if obj.id.get_create_plist().get_layout() == h5py.h5d.VIRTUAL:
                 detail += ' virtual'
         elif isinstance(obj, h5py.Group):
-            if max_depth > 1:
+            if max_depth >= 1:
                 children += [self.group_item_node(obj, key, max_depth - 1)
                              for key in obj]
             else:

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -204,6 +204,13 @@ def print_tree(node, prefix1='', prefix2='', file=None):
         c_prefix2 = prefix2 + ('  ' if islast else '│ ')
         print_tree(node, prefix1=c_prefix1, prefix2=c_prefix2, file=file)
 
+def group_to_str(grp: h5py.Group, expand_attrs=False):
+    sio = io.StringIO()
+    tvb = TreeViewBuilder(expand_attrs=expand_attrs)
+    root = grp.file.filename + '/' + grp.name.lstrip('/')
+    print_tree(tvb.object_node(grp, root), file=sio)
+    return sio.getvalue()
+
 def page(text):
     """Display text in a terminal pager
 

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -119,7 +119,7 @@ class TreeViewBuilder:
             self.colors = ColorsNone
         self.visited = dict()
 
-    def object_node(self, obj, name):
+    def object_node(self, obj, name, max_depth=numpy.inf):
         """Build a tree node for an HDF5 group/dataset
         """
         color_stop = self.colors.reset
@@ -157,14 +157,17 @@ class TreeViewBuilder:
             if obj.id.get_create_plist().get_layout() == h5py.h5d.VIRTUAL:
                 detail += ' virtual'
         elif isinstance(obj, h5py.Group):
-            children += [self.group_item_node(obj, key)
-                         for key in obj]
+            if max_depth > 1:
+                children += [self.group_item_node(obj, key, max_depth - 1)
+                             for key in obj]
+            else:
+                detail = f'\t({len(obj)} children)'
         else:
             detail = ' (unknown h5py type)'
 
         return (color_start + name + color_stop + detail + attr_detail), children
 
-    def group_item_node(self, group, key):
+    def group_item_node(self, group, key, max_depth=numpy.inf):
         """Build a tree node for one key in a group"""
         link = group.get(key, getlink=True)
         if isinstance(link, h5py.SoftLink):
@@ -172,7 +175,7 @@ class TreeViewBuilder:
         elif isinstance(link, h5py.ExternalLink):
             target = '{}/{}'.format(link.filename, link.path)
         else:
-            return self.object_node(group[key], key)
+            return self.object_node(group[key], key, max_depth=max_depth)
 
         line = '{}{}{}\t-> {}'.format(
             self.colors.link, key, self.colors.reset, target)
@@ -204,7 +207,7 @@ def print_tree(node, prefix1='', prefix2='', file=None):
         c_prefix2 = prefix2 + ('  ' if islast else '│ ')
         print_tree(node, prefix1=c_prefix1, prefix2=c_prefix2, file=file)
 
-def group_to_str(grp: h5py.Group, expand_attrs=False):
+def group_to_str(grp: h5py.Group, expand_attrs=False, max_depth=1):
     sio = io.StringIO()
     tvb = TreeViewBuilder(expand_attrs=expand_attrs)
     root = grp.file.filename + '/' + grp.name.lstrip('/')

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -211,7 +211,7 @@ def group_to_str(grp: h5py.Group, expand_attrs=False, max_depth=1):
     sio = io.StringIO()
     tvb = TreeViewBuilder(expand_attrs=expand_attrs)
     root = grp.file.filename + '/' + grp.name.lstrip('/')
-    print_tree(tvb.object_node(grp, root), file=sio)
+    print_tree(tvb.object_node(grp, root, max_depth=max_depth), file=sio)
     return sio.getvalue()
 
 def page(text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "h5py >=2.10",
     "htmlgen",
 ]
-requires-python = ">=3.5"
+requires-python = ">=3.6"
 classifiers = ["License :: OSI Approved :: BSD License"]
 
 [tool.flit.scripts]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,13 +1,13 @@
-from h5glance import generate
+from h5glance import html
 
 
 def test_h5obj_to_html(simple_h5_file):
-    h = generate.h5obj_to_html(simple_h5_file)
+    h = html.h5obj_to_html(simple_h5_file)
     assert 'subgroup1' in h
     assert '</div>' in h
     assert '<!DOCTYPE' not in h  # This is not a full document
 
 def test_make_document(simple_h5_file):
-    h = str(generate.make_document(simple_h5_file))
+    h = str(html.make_document(simple_h5_file))
     assert 'subgroup1' in h
     assert '<!DOCTYPE' in h


### PR DESCRIPTION
![Screenshot of HDF5 group in terminal IPython](https://user-images.githubusercontent.com/327925/89663423-6e617f00-d8cd-11ea-9a3a-cbb468f51e60.png)

This provides a single-layer view of HDF5 groups in terminal IPython. Why a single layer?

1. It's not really useful to print out a list of hundreds of nested groups with no way of controlling it. The HTML interface has expandable bits, and the terminal interface uses a pager to make it searchable. This could still be a problem if you have many entries in one group; I haven't tried to tackle that yet.
2. The notebook creates both the HTML & text representations (for export to other formats), and walking all the subgroups twice would slow it down.

The minimum Python version is increased to 3.6 (f strings!).