### PR TITLE
WIP: Incremental display of tree in the terminal

### DIFF
--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -330,7 +330,7 @@ class MaybePagedOutput(io.TextIOBase):
 
     def _start_pager(self):
         pager_cmd = shlex.split(os.environ.get('PAGER') or 'less -r')
-        self._popen = Popen(pager_cmd, stdin=PIPE, text=True)
+        self._popen = Popen(pager_cmd, stdin=PIPE, universal_newlines=True)
         self.stream = self._popen.stdin
         self._dump_buffer()
 


### PR DESCRIPTION
When you do `h5glance foo.h5`, the code in master goes through all the groups in the file recursively, drawing the terminal tree, and then dumps it into a pager. This branch generates the tree as it goes, and pipes it into the pager. On a file with a few thousand objects, this means a nearly instantaneous view rather than waiting ~1 second.

However, it also has downsides:

- If you search in the pager for a group near the end of the file, a delay reappears. The pager initially reads a finite amount ahead of the current position, and when the buffer is full, the Python code writing data to the pipe blocks. So jumping to the end means the Python code has to finish generating the tree to the end.
- If the HDF5 file has enough groups, it is kept open (read-only) until you view the end of the tree or close the pager. The locking will prevent another process opening it to write.
- The code is somewhat more ugly, IMO: the same recursive code walks the file and prints the tree, because I didn't come up with an elegant way to keep them separate.

So I'm not sure if I should go ahead with this, or stick to what it does in master.