### PR TITLE
Add copylink to links

### DIFF
--- a/h5glance/html.py
+++ b/h5glance/html.py
@@ -87,7 +87,10 @@ def item_for_link(name, link):
         target = f'{link.filename}/{link.path}'
     else:
         target = link.path
-    return ListItem(name, " → ", target)
+    copylink = Link("#", "[📋]")
+    copylink.set_attribute("data-hdf5-path", target)
+    copylink.add_css_classes("h5glance-dataset-copylink")
+    return ListItem(name, " → ", target, " ", copylink)
 
 def leaf_item(name, obj):
     if utils.is_dataset(obj):


### PR DESCRIPTION
Small PR to propose adding a copylink to links.

Downside is that copied path for external link as filename//path is not directly usable.
Alternative would be to put a copylink for both filename and path but it is more cluttered.