### PR TITLE
Add -d/--depth option to choose max tree depth

### DIFF
--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -222,7 +222,8 @@ def page(text):
     pager_cmd = shlex.split(os.environ.get('PAGER') or 'less -r')
     run(pager_cmd, input=text.encode('utf-8'))
 
-def display_h5_obj(file: h5py.File, path=None, expand_attrs=False, slice_expr=None):
+def display_h5_obj(file: h5py.File, path=None, expand_attrs=False, slice_expr=None,
+                   max_depth=numpy.inf):
     """Display information on an HDF5 file, group or dataset
 
     This is the central function for the h5glance command line tool.
@@ -239,7 +240,7 @@ def display_h5_obj(file: h5py.File, path=None, expand_attrs=False, slice_expr=No
         if slice_expr is not None:
             sys.exit("Slicing is only allowed for datasets")
         tvb = TreeViewBuilder(expand_attrs=expand_attrs)
-        print_tree(tvb.object_node(obj, root), file=sio)
+        print_tree(tvb.object_node(obj, root, max_depth=max_depth), file=sio)
     elif isinstance(obj, h5py.Dataset):
         print(root, file=sio)
         print_dataset_info(obj, slice_expr, file=sio)
@@ -315,6 +316,8 @@ def main(argv=None):
     ap.add_argument('--attrs', action='store_true',
         help="Show attributes of groups",
     )
+    ap.add_argument('-d', '--depth', default=numpy.inf, type=numpy.float,
+        help='Show group children only up to a certain depth, all by default.')
     ap.add_argument('-s', '--slice',
         help="Select part of a dataset to examine, using Python slicing and "
              "indexing as for a numpy array, e.g. 0,100:110",
@@ -336,4 +339,5 @@ def main(argv=None):
         path = prompt_for_path(args.file)
 
     with h5py.File(args.file, 'r') as f:
-        display_h5_obj(f, path, slice_expr=args.slice, expand_attrs=args.attrs)
+        display_h5_obj(f, path, slice_expr=args.slice, expand_attrs=args.attrs,
+                       max_depth=args.depth)

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -76,6 +76,17 @@ def test_hard_links(simple_h5_file):
     assert 'folder\t= /group1/subgroup1' in out
     assert 'values\t= /group1/subgroup1/dataset1' in out
 
+def test_max_depth(simple_h5_file):
+    sio = io.StringIO()
+    tvb = terminal.TreeViewBuilder()
+    tree = tvb.object_node(simple_h5_file, simple_h5_file.filename, max_depth=2)
+    terminal.print_tree(tree, file=sio)
+    out = sio.getvalue()
+    assert 'prose\t[UTF-8 string: 2]' in out  # depth=0
+    assert 'scalar\t[int32: scalar]' in out  # depth=1
+    assert 'subgroup1\t(2 children)' in out  # depth=2
+    assert 'dataset1\t[uint64: 200]' not in out  # depth=3
+
 def test_completer(simple_h5_file):
     comp = terminal.H5Completer(simple_h5_file)
     # Complete groups


### PR DESCRIPTION
An HDF file may sometimes have excessive children, which makes navigating through its top tier structures difficult.

The internal APIs already supporting limiting the maximum tree depth, but this was not yet exposed to the command line. This PR adds a corresponding `-d` \ `--depth` option to specify it, defaulting to the previous behaviour of all (`np.inf`).