### PR TITLE
terminal.py: numpy float->cfloat

### DIFF
--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -316,7 +316,7 @@ def main(argv=None):
     ap.add_argument('--attrs', action='store_true',
         help="Show attributes of groups",
     )
-    ap.add_argument('-d', '--depth', default=numpy.inf, type=numpy.float,
+    ap.add_argument('-d', '--depth', default=numpy.inf, type=numpy.cfloat,
         help='Show group children only up to a certain depth, all by default.')
     ap.add_argument('-s', '--slice',
         help="Select part of a dataset to examine, using Python slicing and "

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -316,7 +316,7 @@ def main(argv=None):
     ap.add_argument('--attrs', action='store_true',
         help="Show attributes of groups",
     )
-    ap.add_argument('-d', '--depth', default=numpy.inf, type=numpy.cfloat,
+    ap.add_argument('-d', '--depth', default=numpy.inf, type=float,
         help='Show group children only up to a certain depth, all by default.')
     ap.add_argument('-s', '--slice',
         help="Select part of a dataset to examine, using Python slicing and "


### PR DESCRIPTION
With the existing code, I get:
```
Traceback (most recent call last):
  File "/Users/sasyed/Documents/packages/mambaforge/envs/py3/bin/h5glance", line 8, in <module>
    sys.exit(main())
  File "/Users/sasyed/Documents/packages/mambaforge/envs/py3/lib/python3.10/site-packages/h5glance/terminal.py", line 319, in main
    ap.add_argument('-d', '--depth', default=numpy.inf, type=numpy.float,
  File "/Users/sasyed/Documents/packages/mambaforge/envs/py3/lib/python3.10/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'float'. Did you mean: 'cfloat'?
```