### PR TITLE
Add Python 3.11 on CI, remove 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "h5py >=2.10",
     "htmlgen",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = ["License :: OSI Approved :: BSD License"]
 dynamic = ["version", "description"]
 


### PR DESCRIPTION
Python 3.6 is no longer getting bugfix releases.

If anyone has a decent reason why Python 3.6 support is still useful, let me know - it's not hard to support it for longer. But there are more interesting things to do if no-one needs it.