### PR TITLE
make pager optional in terminal output

### DIFF
--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -251,13 +251,12 @@ def display_h5_obj(file: h5py.File, path=None, expand_attrs=False, slice_expr=No
 
     output = sio.getvalue()
 
-    if use_pager:
-        # If the output has more lines than the terminal, display it in a pager
-        if sys.stdout.isatty():
-            nlines = len(output.splitlines())
-            _, term_lines = get_terminal_size()
-            if nlines > term_lines:
-                return page(output)
+    # If the output has more lines than the terminal, display it in a pager
+    if use_pager and sys.stdout.isatty():
+        nlines = len(output.splitlines())
+        _, term_lines = get_terminal_size()
+        if nlines > term_lines:
+            return page(output)
 
     print(output)
 

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -225,7 +225,7 @@ def page(text):
     run(pager_cmd, input=text.encode('utf-8'))
 
 def display_h5_obj(file: h5py.File, path=None, expand_attrs=False, slice_expr=None,
-                   max_depth=numpy.inf):
+                   max_depth=numpy.inf, use_pager=True):
     """Display information on an HDF5 file, group or dataset
 
     This is the central function for the h5glance command line tool.
@@ -249,13 +249,15 @@ def display_h5_obj(file: h5py.File, path=None, expand_attrs=False, slice_expr=No
     else:
         sys.exit("What is this? " + repr(obj))
 
-    # If the output has more lines than the terminal, display it in a pager
     output = sio.getvalue()
-    if sys.stdout.isatty():
-        nlines = len(output.splitlines())
-        _, term_lines = get_terminal_size()
-        if nlines > term_lines:
-            return page(output)
+
+    if use_pager:
+        # If the output has more lines than the terminal, display it in a pager
+        if sys.stdout.isatty():
+            nlines = len(output.splitlines())
+            _, term_lines = get_terminal_size()
+            if nlines > term_lines:
+                return page(output)
 
     print(output)
 
@@ -318,6 +320,10 @@ def main(argv=None):
     ap.add_argument('--attrs', action='store_true',
         help="Show attributes of groups",
     )
+    ap.add_argument('--pager', action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use a pager to display output if it is too long (default: on)",
+    )
     ap.add_argument('-d', '--depth', default=numpy.inf, type=float,
         help='Show group children only up to a certain depth, all by default.')
     ap.add_argument('-s', '--slice',
@@ -342,4 +348,4 @@ def main(argv=None):
 
     with h5py.File(args.file, 'r') as f:
         display_h5_obj(f, path, slice_expr=args.slice, expand_attrs=args.attrs,
-                       max_depth=args.depth)
+                       max_depth=args.depth, use_pager=args.pager)


### PR DESCRIPTION
I frequently use `h5glance` within another program that has paging functionality (e.g. `tmux` or `vim`). In these cases, I find it inconvenient to have multiple pagers because I have to have the correct one focused to scroll.

This PR adds a pair of command line options, `--pager` and `--no-pager`, that allow for the pager to be turned off. By default, the pager is on, so there is no change to the default behavior.
