### PR TITLE
Add support for NO_COLOR environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ In the terminal, you can get a tree view of a file::
 
 The names of datasets, groups and links are colour-coded by default.
 If you want to disable this, set the environment variable ``H5GLANCE_COLORS=0``.
+H5Glance also respects the `NO_COLOR convention <https://no-color.org/>`_.
 
 Inspect a group or dataset inside it::
 

--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -106,6 +106,9 @@ def use_colors():
     env = os.environ.get('H5GLANCE_COLORS', '')
     if env:
         return env != '0'
+    # any non-empty string works for NO_COLOR - https://no-color.org/
+    if os.environ.get('NO_COLOR', ''):
+        return False
     return sys.stdout.isatty()
 
 class TreeViewBuilder:


### PR DESCRIPTION
This is a common convention that many terminal programs respect - set `NO_COLOR=1` to disable coloured output.

https://no-color.org/