### PR TITLE
Add numpy print option in order to prevent showing the datatype 

### DIFF
--- a/h5glance/terminal.py
+++ b/h5glance/terminal.py
@@ -15,6 +15,8 @@ import sys
 from .datatypes import fmt_dtype
 from .utils import fmt_shape
 
+numpy.set_printoptions(legacy='1.25')
+
 layout_names = {
     h5py.h5d.COMPACT: 'Compact',
     h5py.h5d.CONTIGUOUS: 'Contiguous',


### PR DESCRIPTION
Add numpy print option in order to prevent showing the datatype on each print.

The relevant portion of the numpy documentation states that setting `legacy='1.25'`:

> [...] means that numeric scalars are printed without their type information, e.g. as `3.0` rather than `np.float64(3.0)`.